### PR TITLE
Update to Reflect Testing

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@
  * Author URI: http://www.studiopress.com/
  * Text Domain: genesis-tabs
  *
- * Version: 1.0.0
+ * Version: 1.0.1
  *
  * License: GNU General Public License v2.0 (or later)
  * License URI: https://opensource.org/licenses/gpl-license.php
@@ -41,7 +41,7 @@ function genesis_tabs_activation_check() {
 
 }
 
-define( 'GENESIS_TABS_PLUGIN_VERSION', '1.0.0' );
+define( 'GENESIS_TABS_PLUGIN_VERSION', '1.0.1' );
 
 define( 'GENESIS_TABS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENESIS_TABS_URL', plugins_url( '', __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, wpmuguru
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: tabs, ui-tabs, genesis, genesiswp, studiopress
 Requires at least: 3.7
-Tested up to: 4.8.3
+Tested up to: 5.2.2
 Stable tag: 1.0.0
 
 This plugin allows you to create a tabbed section, via a widget, that can display the featured image, along with the title and excerpt from each post.
@@ -24,6 +24,9 @@ Note: This plugin only supports Genesis child themes.
 1. In the "Widgets" screen, drag the "Genesis Slider" widget to the widget area of your choice, and configure.
 
 == Changelog ==
+
+= 1.0.1 =
+* Test with latest WordPress version
 
 = 1.0.0 =
 * Conform to WordPress Development Standards for PHP

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: tabs, ui-tabs, genesis, genesiswp, studiopress
 Requires at least: 3.7
 Tested up to: 5.2.2
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 
 This plugin allows you to create a tabbed section, via a widget, that can display the featured image, along with the title and excerpt from each post.
 


### PR DESCRIPTION
Update the `Tested up to` value and the changelog. This update will remove the `This plugin hasn’t been tested with the latest 3 major releases of WordPress` on wordpress.org.