### PR TITLE
Soft deprecate Genesis Tabs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,12 @@ Stable tag: 0.9.5
 
 This plugin allows you to create a tabbed section, via a widget, that can display the featured image, along with the title and excerpt from each post.
 
+== DEPRECATION NOTICE ==
+
+This plugin is now deprecated and will no longer receive feature updates.
+
+We recommend replacing the Genesis Featured Tabs widget with a Genesis Featured Post or Page widget, image widget, or slider widget.
+
 == Description ==
 
 This plugin allows you to create a tabbed section, via a widget, that can display the featured image, along with the title and excerpt from each post.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, wpmuguru, marksabbath, mikehale, dreamwhi
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: tabs, ui-tabs, genesis, genesiswp, studiopress
 Requires at least: 3.7
-Tested up to: 5.2.2
+Tested up to: 5.4
 Stable tag: 0.9.5
 
 This plugin allows you to create a tabbed section, via a widget, that can display the featured image, along with the title and excerpt from each post.


### PR DESCRIPTION
- Adds a soft deprecation notice.
- Bumps tested up to to 5.4.

This plugin is used by the [News Pro theme](https://my.studiopress.com/themes/news/) on the homepage.

I'll submit a PR for News Pro to replace the Featured Tabs widget from this plugin with a Featured Post/Page widget instead.